### PR TITLE
Fix Hanami::Repository superclass

### DIFF
--- a/lib/hanami/pagination/extentions.rb
+++ b/lib/hanami/pagination/extentions.rb
@@ -1,7 +1,7 @@
-module Hanami
-  class Repository
-    def self.enable_pagination!
-      container.relation(relation).class.use(:pagination)
-    end
+require "hanami/repository"
+
+Hanami::Repository.class_eval do
+  def self.enable_pagination!
+    container.relation(relation).class.use(:pagination)
   end
 end


### PR DESCRIPTION
I'm trying to migrate `hanami/contributors` to `hanami-1.1.0.beta1`, and I run in the following error while trying to run the specs for that project:

```
/Users/luca/.gem/ruby/2.4.1/bundler/gems/model-2e7d20826df3/lib/hanami/repository.rb:110:in `<module:Hanami>': superclass mismatch for class Repository (TypeError)
```

This is due to the fact that `hanami-pagination` is somehow required first than `hanami-model`. The way that this gem declares `Hanami::Repository`, makes it to inherit **implicitly** from `Object`.

When `hanami-model` is loaded, it defines "again" that constant, and it tries to set the real superclass (`ROM::Repository::Root`), but this attempt makes Ruby sad 😢 and the process blows up.