### PR TITLE
paginate-helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,49 @@ When you include `Pagination::Action` to your action you get `pager` getter with
 - `previous_page_path`
 - `next_page_path`
 - `n_page_path`
+- `paginate`
 
 
 ### View
+
+#### `paginate(page)`
+
+Returns `<nav>` tag with links to first, last and closest pages. For example:
+
+```ruby
+paginate(:items) # where `:items` is a named route
+```
+
+when there is 11 pages, will returns:
+
+```html
+<nav class="pagination">
+  <a href="/items?page=1" class="pagination-first-page">
+    1
+  </a>
+  <span class="pagination-ellipsis">
+    ...
+  </span>
+  <a href="/items?page=4" class="pagination-previous-page">
+    4
+  </a>
+  <span class="pagination-current-page">
+    5
+  </span>
+  <a href="/items?page=6" class="pagination-next-page">
+    6
+  </a>
+  <span class="pagination-ellipsis">
+    ...
+  </span>
+  <a href="/items?page=11" class="pagination-last-page">
+    11
+  </a>
+</nav>
+
+```
+Every elements has special css-classes, so it is easy to change pagination look.
+
 #### `next_page_url`
 Returns string with url to next page. Example:
 
@@ -182,4 +222,3 @@ end
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/hanami-pagination.gemspec
+++ b/hanami-pagination.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "hanami-model", "~> 1.0"
+  spec.add_dependency "hanami-helpers", "~> 1.1"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/hanami/pagination/mock_pager.rb
+++ b/lib/hanami/pagination/mock_pager.rb
@@ -23,6 +23,14 @@ module Hanami
       def total_pages
         @total_pages
       end
+
+      def first_page?
+        current_page == 1
+      end
+
+      def last_page?
+        current_page == total_pages
+      end
     end
   end
 end

--- a/lib/hanami/pagination/pager.rb
+++ b/lib/hanami/pagination/pager.rb
@@ -23,6 +23,10 @@ module Hanami
         pager.total_pages
       end
 
+      def current_page
+        pager.current_page
+      end
+
       def current_page?(page)
         pager.current_page == page
       end

--- a/lib/hanami/pagination/view.rb
+++ b/lib/hanami/pagination/view.rb
@@ -1,6 +1,10 @@
+require 'hanami/helpers'
+
 module Hanami
   module Pagination
     module View
+      include Hanami::Helpers
+
       def next_page_url
         page_url(pager.next_page)
       end
@@ -23,6 +27,58 @@ module Hanami
 
       def n_page_path(page, n)
         routes.path(page, **params, page: n)
+      end
+
+      def paginate(page)
+        html.nav(class: 'pagination') do
+          content = []
+
+          content << first_page_tag unless pager.first_page?
+          content << ellipsis_tag if pager.current_page > 3
+          content << previous_page_tag(page) if pager.current_page > 2
+          content << current_page_tag
+          content << next_page_tag(page) if (pager.total_pages - pager.current_page) > 1
+          content << ellipsis_tag if (pager.total_pages - pager.current_page) > 3
+          content << last_page_tag unless pager.last_page?
+
+          raw(content.map(&:to_s).join)
+        end
+      end
+
+      def first_page_tag
+        html.a(href: page_url(1), class: 'pagination-first-page') do
+          '1'
+        end
+      end
+
+      def previous_page_tag(page)
+        html.a(href: previous_page_path(page), class: 'pagination-previous-page') do
+          pager.prev_page
+        end
+      end
+
+      def current_page_tag
+        html.span(class: 'pagination-current-page') do
+          pager.current_page
+        end
+      end
+
+      def last_page_tag
+        html.a(href: page_url(pager.total_pages), class: 'pagination-last-page') do
+          pager.total_pages
+        end
+      end
+
+      def next_page_tag(page)
+        html.a(href: next_page_path(page), class: 'pagination-next-page') do
+          pager.next_page
+        end
+      end
+
+      def ellipsis_tag
+        html.span(class: 'pagination-ellipsis') do
+          '...'
+        end
       end
     end
   end

--- a/spec/pager_spec.rb
+++ b/spec/pager_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe Hanami::Pagination::Pager do
     it { expect(pager.total_pages).to eq 10 }
   end
 
+  describe '#current_page' do
+    it { expect(pager.current_page).to eq 1 }
+  end
+
   describe '#current_page?' do
     it { expect(pager.current_page?(1)).to eq true }
     it { expect(pager.current_page?(2)).to eq false }

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -2,8 +2,13 @@ module View
   class Index < ViewMock
     include Hanami::Pagination::View
 
+    def initialize(*args)
+      super
+      @params_page = args[0]
+    end
+
     def params
-      Params.new
+      Params.new(params_page)
     end
 
     def routes
@@ -13,8 +18,12 @@ module View
     class Params
       attr_reader :params, :env
 
+      def initialize(params_page)
+        @params_page = params_page
+      end
+
       def env
-       { 'REQUEST_PATH' => '/books' }
+        { 'REQUEST_PATH' => '/books' }
       end
 
       def to_h
@@ -27,8 +36,16 @@ module View
       end
 
       def params
-        { country: 'rus' }
+        if params_page.nil?
+          { country: 'rus' }
+        else
+          { country: 'rus', page: params_page.to_s }
+        end
       end
+
+      private
+
+      attr_reader :params_page
     end
 
     class Routes
@@ -39,6 +56,10 @@ module View
         result
       end
     end
+
+    private
+
+    attr_reader :params_page
   end
 end
 
@@ -69,5 +90,108 @@ RSpec.describe Hanami::Pagination::View do
 
   describe '#n_page_path' do
     it { expect(view.n_page_path(:users, 7)).to eq '/users?country=rus&page=7' }
+  end
+
+  describe 'html' do
+    describe '#paginate' do
+      let(:html) { view.paginate(:books).to_s }
+
+      it 'with <nav class="pagination"> tag' do
+        expect(html).to include('<nav class="pagination">')
+        expect(html).to include('</nav>')
+      end
+
+      context 'when page is 1/10' do
+        it { expect(html).not_to include 'pagination-first-page' }
+        it { expect(html).not_to include 'pagination-previous-page' }
+        it { expect(html).to include 'pagination-current-page' }
+        it { expect(html).to include 'pagination-next-page' }
+        it { expect(html).to include 'pagination-last-page' }
+        it { expect(html.scan('pagination-ellipsis').count).to eql 1 }
+      end
+
+      context 'when page is 5/10' do
+        let(:view) { View::Index.new(5) }
+        let(:html) { view.paginate(:books).to_s }
+
+        it { expect(html).to include 'pagination-first-page' }
+        it { expect(html).to include 'pagination-previous-page' }
+        it { expect(html).to include 'pagination-current-page' }
+        it { expect(html).to include 'pagination-next-page' }
+        it { expect(html).to include 'pagination-last-page' }
+        it { expect(html.scan('pagination-ellipsis').count).to eql 2 }
+      end
+
+      context 'when page is 10/10' do
+        let(:view) { View::Index.new(10) }
+        let(:html) { view.paginate(:books).to_s }
+
+
+        it { expect(html).to include 'pagination-first-page' }
+        it { expect(html).to include 'pagination-previous-page' }
+        it { expect(html).to include 'pagination-current-page' }
+        it { expect(html).not_to include 'pagination-next-page' }
+        it { expect(html).not_to include 'pagination-last-page' }
+        it { expect(html.scan('pagination-ellipsis').count).to eql 1 }
+      end
+    end
+
+    describe '#first_page_tag' do
+      let(:html) { view.first_page_tag.to_s }
+
+      it { expect(html).to include '<a ' }
+      it { expect(html).to include 'href="/books?page=1"' }
+      it { expect(html).to include 'class="pagination-first-page"' }
+      it { expect(html).to include '1' }
+      it { expect(html).to include '</a>' }
+    end
+
+    describe '#previous_page_tag' do
+      let(:html) { view.previous_page_tag(:books).to_s }
+
+      it { expect(html).to include '<a ' }
+      it { expect(html).to include 'href="/books?country=rus&page=1"' }
+      it { expect(html).to include 'class="pagination-previous-page"' }
+      it { expect(html).to include '1' }
+      it { expect(html).to include '</a>' }
+    end
+
+    describe '#current_page_tag' do
+      let(:html) { view.current_page_tag.to_s }
+
+      it { expect(html).to include '<span ' }
+      it { expect(html).to include 'class="pagination-current-page"' }
+      it { expect(html).to include '1' }
+      it { expect(html).to include '</span>' }
+    end
+
+    describe '#last_page_tag' do
+      let(:html) { view.last_page_tag.to_s }
+
+      it { expect(html).to include '<a ' }
+      it { expect(html).to include 'href="/books?page=10"' }
+      it { expect(html).to include 'class="pagination-last-page"' }
+      it { expect(html).to include '10' }
+      it { expect(html).to include '</a>' }
+    end
+
+    describe '#next_page_tag' do
+      let(:html) { view.next_page_tag(:books).to_s }
+
+      it { expect(html).to include '<a ' }
+      it { expect(html).to include 'href="/books?country=rus&page=2"' }
+      it { expect(html).to include 'class="pagination-next-page"' }
+      it { expect(html).to include '2' }
+      it { expect(html).to include '</a>' }
+    end
+
+    describe '#ellipsis_tag' do
+      let(:html) { view.ellipsis_tag.to_s }
+
+      it { expect(html).to include '<span ' }
+      it { expect(html).to include 'class="pagination-ellipsis"' }
+      it { expect(html).to include '...' }
+      it { expect(html).to include '</span>' }
+    end
   end
 end


### PR DESCRIPTION
Added `#paginate` helper with specs and readme.

Unlike Kaminari it is using html helpers instead of special html template file. So it needs `hanami/helpers` dependency. But I sure, it will makes gem more testable and flexible in future.

Thank you for Hanami.