### PR TITLE
parameters for first page and last page

### DIFF
--- a/lib/hanami/pagination/view.rb
+++ b/lib/hanami/pagination/view.rb
@@ -33,20 +33,20 @@ module Hanami
         html.nav(class: 'pagination') do
           content = []
 
-          content << first_page_tag unless pager.first_page?
+          content << first_page_tag(page) unless pager.first_page?
           content << ellipsis_tag if pager.current_page > 3
           content << previous_page_tag(page) if pager.current_page > 2
           content << current_page_tag
           content << next_page_tag(page) if (pager.total_pages - pager.current_page) > 1
           content << ellipsis_tag if (pager.total_pages - pager.current_page) > 3
-          content << last_page_tag unless pager.last_page?
+          content << last_page_tag(page) unless pager.last_page?
 
           raw(content.map(&:to_s).join)
         end
       end
 
-      def first_page_tag
-        html.a(href: page_url(1), class: 'pagination-first-page') do
+      def first_page_tag(page)
+        html.a(href: n_page_path(page, 1), class: 'pagination-first-page') do
           '1'
         end
       end
@@ -63,8 +63,8 @@ module Hanami
         end
       end
 
-      def last_page_tag
-        html.a(href: page_url(pager.total_pages), class: 'pagination-last-page') do
+      def last_page_tag(page)
+        html.a(href: n_page_path(page, pager.total_pages), class: 'pagination-last-page') do
           pager.total_pages
         end
       end

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -137,10 +137,10 @@ RSpec.describe Hanami::Pagination::View do
     end
 
     describe '#first_page_tag' do
-      let(:html) { view.first_page_tag.to_s }
+      let(:html) { view.first_page_tag(:books).to_s }
 
       it { expect(html).to include '<a ' }
-      it { expect(html).to include 'href="/books?page=1"' }
+      it { expect(html).to include 'href="/books?country=rus&page=1"' }
       it { expect(html).to include 'class="pagination-first-page"' }
       it { expect(html).to include '1' }
       it { expect(html).to include '</a>' }
@@ -166,10 +166,10 @@ RSpec.describe Hanami::Pagination::View do
     end
 
     describe '#last_page_tag' do
-      let(:html) { view.last_page_tag.to_s }
+      let(:html) { view.last_page_tag(:books).to_s }
 
       it { expect(html).to include '<a ' }
-      it { expect(html).to include 'href="/books?page=10"' }
+      it { expect(html).to include 'href="/books?country=rus&page=10"' }
       it { expect(html).to include 'class="pagination-last-page"' }
       it { expect(html).to include '10' }
       it { expect(html).to include '</a>' }


### PR DESCRIPTION
Hi.
Parameters were present for next and previous pages,  but lost for the first and last pages.
I fixed this issue.