### PR TITLE
Fix paginate helper issues

### DIFF
--- a/lib/hanami/pagination/pager.rb
+++ b/lib/hanami/pagination/pager.rb
@@ -50,7 +50,7 @@ module Hanami
       end
 
       def last_page?
-        pager.current_page == pager.total_pages
+        pager.total < 1 || pager.current_page == pager.total_pages
       end
     end
   end

--- a/lib/hanami/pagination/pager.rb
+++ b/lib/hanami/pagination/pager.rb
@@ -16,7 +16,7 @@ module Hanami
       end
 
       def total
-        pager.total
+        @total ||= pager.total
       end
 
       def total_pages

--- a/spec/pager_spec.rb
+++ b/spec/pager_spec.rb
@@ -85,5 +85,12 @@ RSpec.describe Hanami::Pagination::Pager do
       let(:current_page) { 10 }
       it { expect(pager.last_page?).to eq true }
     end
+
+    context 'with zero elements' do
+      let(:current_page) { 1 }
+      let(:total_pages) { 0 }
+
+      it { expect(pager.last_page?).to eq true }
+    end
   end
 end

--- a/spec/pager_spec.rb
+++ b/spec/pager_spec.rb
@@ -29,6 +29,11 @@ RSpec.describe Hanami::Pagination::Pager do
 
   describe '#total' do
     it { expect(pager.total).to eq 10 }
+
+    it 'touches pager total method only once' do
+      expect(mock_pager).to receive(:total).exactly(1).and_return(10)
+      3.times { pager.total }
+    end
   end
 
   describe '#total_pages' do


### PR DESCRIPTION
This PR adds:

1. Fix for case when there are zero elements returned by a query.
2. Improvement to prevent from making COUNT query on DB everytime pagination helper touches total method.