### PR TITLE
[#13] Fix for issue #13

### DIFF
--- a/lib/hanami/pagination/mock_pager.rb
+++ b/lib/hanami/pagination/mock_pager.rb
@@ -1,27 +1,15 @@
 module Hanami
   module Pagination
     class MockPager
-      attr_reader :current_page, :total_pages
+      attr_reader :current_page, :total_pages, :total,
+                  :next_page, :prev_page
 
       def initialize(current_page, total_pages)
         @current_page = current_page
         @total_pages = total_pages
-      end
-
-      def next_page
-        [current_page + 1, total_pages].min
-      end
-
-      def prev_page
-        [current_page - 1, 1].max
-      end
-
-      def total
-        total_pages
-      end
-
-      def total_pages
-        @total_pages
+        @total = total_pages
+        @next_page = [current_page + 1, total_pages].min
+        @prev_page = [current_page - 1, 1].max
       end
 
       def first_page?

--- a/lib/hanami/pagination/pager.rb
+++ b/lib/hanami/pagination/pager.rb
@@ -20,7 +20,7 @@ module Hanami
       end
 
       def total_pages
-        pager.total_pages
+        @total_pages ||= pager.total_pages
       end
 
       def current_page

--- a/lib/hanami/pagination/pager.rb
+++ b/lib/hanami/pagination/pager.rb
@@ -6,11 +6,11 @@ module Hanami
 
       def initialize(pager)
         @pager = pager
-        @next_page = pager.next_page
         @prev_page = pager.prev_page
         @total = pager.total
         @total_pages = pager.total_pages
         @current_page = pager.current_page
+        @next_page = next_page_value
       end
 
       def current_page?(page)
@@ -37,6 +37,12 @@ module Hanami
 
       def last_page?
         total < 1 || current_page == total_pages
+      end
+
+      private
+
+      def next_page_value
+        current_page + 1 if total_pages >= current_page + 1
       end
     end
   end

--- a/lib/hanami/pagination/pager.rb
+++ b/lib/hanami/pagination/pager.rb
@@ -1,56 +1,42 @@
 module Hanami
   module Pagination
     class Pager
-      attr_reader :pager
+      attr_reader :pager, :next_page, :prev_page,
+                  :total, :total_pages, :current_page
 
       def initialize(pager)
         @pager = pager
-      end
-
-      def next_page
-        pager.next_page
-      end
-
-      def prev_page
-        pager.prev_page
-      end
-
-      def total
-        @total ||= pager.total
-      end
-
-      def total_pages
-        @total_pages ||= pager.total_pages
-      end
-
-      def current_page
-        pager.current_page
+        @next_page = pager.next_page
+        @prev_page = pager.prev_page
+        @total = pager.total
+        @total_pages = pager.total_pages
+        @current_page = pager.current_page
       end
 
       def current_page?(page)
-        pager.current_page == page
+        current_page == page
       end
 
       def pages_range(delta: 3)
-        first = pager.current_page - delta
+        first = current_page - delta
         first = first > 0 ? first : 1
 
-        last = pager.current_page + delta
-        last = last < pager.total_pages ? last : pager.total_pages
+        last = current_page + delta
+        last = last < total_pages ? last : total_pages
 
         (first..last).to_a
       end
 
       def all_pages
-        (1..pager.total_pages).to_a
+        (1..total_pages).to_a
       end
 
       def first_page?
-        pager.current_page == 1
+        current_page == 1
       end
 
       def last_page?
-        pager.total < 1 || pager.current_page == pager.total_pages
+        total < 1 || current_page == total_pages
       end
     end
   end

--- a/spec/pager_spec.rb
+++ b/spec/pager_spec.rb
@@ -38,6 +38,11 @@ RSpec.describe Hanami::Pagination::Pager do
 
   describe '#total_pages' do
     it { expect(pager.total_pages).to eq 10 }
+
+    it 'touches pager total_pages method only once' do
+      expect(mock_pager).to receive(:total_pages).exactly(1).and_return(10)
+      3.times { pager.total_pages }
+    end
   end
 
   describe '#current_page' do

--- a/spec/pager_spec.rb
+++ b/spec/pager_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Hanami::Pagination::Pager do
     it { expect(pager.next_page).to eq 2 }
 
     context 'on other page' do
-      let(:current_page) { 10 }
+      let(:current_page) { 9 }
       it { expect(pager.next_page).to eq 10 }
     end
   end


### PR DESCRIPTION
This PR changes:
1. Pager class now does not delegate methods logic to rom-sql pager class. All methods responsible for creating additional count query execution are assigned to class fields.
2. Test logic has been corrected. 
```ruby
context 'on other page' do
   let(:current_page) { 9 }
   it { expect(pager.next_page).to eq 10 }
end
```

** Only two count queries are left. The first one when total is touched and the second one when total_pages is touched.